### PR TITLE
Add `list-style` in markdown-body

### DIFF
--- a/static/assets/css/markdown.css
+++ b/static/assets/css/markdown.css
@@ -413,6 +413,11 @@
   margin-top: 0;
   margin-bottom: 0;
   padding-left: 2em;
+  list-style-type: disc;
+}
+
+.markdown-body ol {
+  list-style-type: decimal;
 }
 
 .markdown-body ol ol,


### PR DESCRIPTION
Tailwindcss removes list styles (bullets, number) from `<ol>` and `<ul>`. I have added the corresponded `list-style-type` to both elements in `markdown.css` file.